### PR TITLE
Associate tasks to users

### DIFF
--- a/src/Controller/TaskController.php
+++ b/src/Controller/TaskController.php
@@ -29,6 +29,8 @@ class TaskController extends Controller
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
+            $task->setUser($this->getUser());
+
             $em = $this->getDoctrine()->getManager();
 
             $em->persist($task);

--- a/src/Entity/Task.php
+++ b/src/Entity/Task.php
@@ -1,4 +1,4 @@
-<?php
+<?php /** @noinspection PhpIllegalPsrClassPathInspection */
 
 namespace App\Entity;
 
@@ -17,6 +17,12 @@ class Task
      * @ORM\GeneratedValue(strategy="AUTO")
      */
     private $id;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="User", inversedBy="tasks")
+     * @ORM\JoinColumn(name="user_id", referencedColumnName="id")
+     */
+    private $user;
 
     /**
      * @ORM\Column(type="datetime")
@@ -49,6 +55,18 @@ class Task
     public function getId()
     {
         return $this->id;
+    }
+
+    public function getUser()
+    {
+        return $this->user;
+    }
+
+    public function setUser($user)
+    {
+        $this->user = $user;
+
+        return $this;
     }
 
     public function getCreatedAt()

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -1,7 +1,8 @@
-<?php
+<?php /** @noinspection PhpIllegalPsrClassPathInspection */
 
 namespace App\Entity;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -38,6 +39,16 @@ class User implements UserInterface
      * @Assert\Email(message="Le format de l'adresse n'est pas correcte.")
      */
     private $email;
+
+    /**
+     * @ORM\OneToMany(targetEntity="Task", mappedBy="user")
+     */
+    private $tasks;
+
+    public function __construct()
+    {
+        $this->tasks = new ArrayCollection();
+    }
 
     public function getId()
     {
@@ -82,6 +93,11 @@ class User implements UserInterface
     public function getRoles()
     {
         return array('ROLE_USER');
+    }
+
+    public function getTasks()
+    {
+        return $this->tasks;
     }
 
     public function eraseCredentials()

--- a/src/Form/TaskType.php
+++ b/src/Form/TaskType.php
@@ -13,7 +13,6 @@ class TaskType extends AbstractType
         $builder
             ->add('title')
             ->add('content', TextareaType::class)
-            //->add('author') ===> must be the user authenticated
         ;
     }
 }


### PR DESCRIPTION
This associates a task to a user. For tasks already created and with no associated users, the task getUser() getter will return the string 'Anonymous'.

Resolves: #4.